### PR TITLE
Automatically build missing values for valid fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,29 +23,13 @@ now set value
 ```ruby
 user = User.create
 
-user.set_dynabute_value( name: 'age', value: 40 )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: 40>
-user.set_dynabute_value( name: 'skinny', value: true )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: true>
-user.save
-# => true
-
-# or update single value
 user.set_dynabute_value( name: 'age', value: 35 ).save
 # => true
 ```
 
 check the value
 ```ruby
-user.get_dynabute_value(name: 'age')
-# => 35
-```
-
-or check entire value object
-```ruby
-value_obj = user.dynabute_value( name: 'age' )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: 35>
-value_obj.value
+user.dynabute_value( name: 'age' ).value
 # => 35
 ```
 
@@ -53,75 +37,6 @@ values can also be referenced by `dynabute_<field name>_value(s)`
 ```ruby
 user.dynabute_age_value.value
 # => 35
-```
-
-set values for fields which can contain more than one value
-```ruby
-user = User.create
-
-user.set_dynabute_value( name: 'personalities', value: 'good' )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">
-user.set_dynabute_value( name: 'personalities', value: 'bad' )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "bad">
-user.set_dynabute_value( name: 'personalities', value: 'ugly' )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">
-user.save
-# => true
-```
-
-get values for fields which can contain more than one value
-```ruby
-user = User.first
-
-user.get_dynabute_value( name: 'personalities' )
-# => ["good", "bad", "ugly"]
-
-user.dynabute_value( name: 'personalities' )
-# => [#<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">,
-#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "bad">,
-#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">]
-```
-
-update specific value for field with `has_many` option
-```ruby
-user = User.first
-
-values_obj = user.dynabute_value( name: 'personalities' )
-# => [#<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">,
-#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "bad">,
-#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">]
-good_value_obj = values_obj.first
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">
-bad_value_obj = values_obj.last
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">
-user.set_dynabute_value( name: 'personalities', value: 'very good', value_id: good_value_obj.id )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "very good">
-user.set_dynabute_value( name: 'personalities', value: 'very ugly', value_id: bad_value_obj.id )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "very ugly">
-user.save
-# => true
-
-# in case all changes are not required to be saved within db transaction,
-# each value can be saved separately.
-good_value_obj.value = 'very very good'
-# => "very very good"
-good_value_obj.save
-```
-
-remove value
-```ruby
-user = User.first
-
-user.remove_dynabute_value( name: 'age' )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: 35>
-
-value_obj = user.dynabute_value( name: 'personalities' ).first
-user.remove_dynabute_value( name: 'personalities', value_id: value_obj.id )
-# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">
-
-user.remove_dynabute_value( name: 'personalities' )
-# => [#<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "bad">,
-#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">]
 ```
 
 nested attributes of glory
@@ -172,6 +87,15 @@ user.dynabute_value(name: 'hobbies').map(&:option)
 #     #<Dynabute::Option:0x007fb26c446238 id: 6, field_id: 5, label: "swimming">]
 ```
 
+remove value
+
+```
+user.remove_dynabute_value(name: 'age')
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: 35>
+```
+
+
+
 ## Installation
 Add this line to your application's Gemfile:
 
@@ -185,6 +109,9 @@ $ bundle install
 $ rails generate dynabute:install
 $ rake db:migrate
 ```
+## Contributors
+
+[<img src="https://github.com/CrAsH1101.png" width="60px;"/><br /><sub><a href="https://github.com/CrAsH1101">CrAsH1101</a></sub>](https://github.com/CrAsH1101)
 
 ## Contributing
 
@@ -198,7 +125,6 @@ $ cd ../../
 $ bundle exec rspec
 ```
 
-yea?
 
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -23,13 +23,29 @@ now set value
 ```ruby
 user = User.create
 
-user.build_dynabute_value( name: 'age', value: 35 ).save
-# => <Dynabute::Values::IntegerValue:0x007faba5279540 id: 1, field_id: 1, dynabutable_id: 1, dynabutable_type: "User", value: 35>
+user.set_dynabute_value( name: 'age', value: 40 )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: 40>
+user.set_dynabute_value( name: 'skinny', value: true )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: true>
+user.save
+# => true
+
+# or update single value
+user.set_dynabute_value( name: 'age', value: 35 ).save
+# => true
 ```
 
 check the value
 ```ruby
-user.dynabute_value( name: 'age' ).value
+user.get_dynabute_value(name: 'age')
+# => 35
+```
+
+or check entire value object
+```ruby
+value_obj = user.dynabute_value( name: 'age' )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: 35>
+value_obj.value
 # => 35
 ```
 
@@ -37,6 +53,75 @@ values can also be referenced by `dynabute_<field name>_value(s)`
 ```ruby
 user.dynabute_age_value.value
 # => 35
+```
+
+set values for fields which can contain more than one value
+```ruby
+user = User.create
+
+user.set_dynabute_value( name: 'personalities', value: 'good' )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">
+user.set_dynabute_value( name: 'personalities', value: 'bad' )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "bad">
+user.set_dynabute_value( name: 'personalities', value: 'ugly' )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">
+user.save
+# => true
+```
+
+get values for fields which can contain more than one value
+```ruby
+user = User.first
+
+user.get_dynabute_value( name: 'personalities' )
+# => ["good", "bad", "ugly"]
+
+user.dynabute_value( name: 'personalities' )
+# => [#<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">,
+#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "bad">,
+#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">]
+```
+
+update specific value for field with `has_many` option
+```ruby
+user = User.first
+
+values_obj = user.dynabute_value( name: 'personalities' )
+# => [#<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">,
+#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "bad">,
+#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">]
+good_value_obj = values_obj.first
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">
+bad_value_obj = values_obj.last
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">
+user.set_dynabute_value( name: 'personalities', value: 'very good', value_id: good_value_obj.id )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "very good">
+user.set_dynabute_value( name: 'personalities', value: 'very ugly', value_id: bad_value_obj.id )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "very ugly">
+user.save
+# => true
+
+# in case all changes are not required to be saved within db transaction,
+# each value can be saved separately.
+good_value_obj.value = 'very very good'
+# => "very very good"
+good_value_obj.save
+```
+
+remove value
+```ruby
+user = User.first
+
+user.remove_dynabute_value( name: 'age' )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: 35>
+
+value_obj = user.dynabute_value( name: 'personalities' ).first
+user.remove_dynabute_value( name: 'personalities', value_id: value_obj.id )
+# => #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "good">
+
+user.remove_dynabute_value( name: 'personalities' )
+# => [#<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "bad">,
+#     #<Dynabute::Values::StringValue:0x0000 ... dynabutable_type: "User", value: "ugly">]
 ```
 
 nested attributes of glory
@@ -102,6 +187,17 @@ $ rake db:migrate
 ```
 
 ## Contributing
+
+#### Rspec: set test environment
+```bash
+$ bundle install
+$ cd spec/dummy/
+$ RAILS_ENV=test bundle exec rake db:create
+$ RAILS_ENV=test bundle exec rake db:migrate
+$ cd ../../
+$ bundle exec rspec
+```
+
 yea?
 
 ## License

--- a/lib/dynabute/dynabutable.rb
+++ b/lib/dynabute/dynabutable.rb
@@ -4,6 +4,7 @@ require 'dynabute/nested_attributes'
 
 module Dynabute
   module Dynabutable
+    class ValueNotFound < StandardError; end
     extend ActiveSupport::Concern
 
     included do
@@ -36,18 +37,73 @@ module Dynabute
       end
 
       def dynabute_value(name: nil, field_id: nil, field: nil)
-        field = find_field(name, field_id, field)
-
-        if field.has_many
-          send(Util.value_relation_name(field.value_type)).select{|v| v.field_id == field.id }
+        field_obj = find_field(name, field_id, field)
+        field_values = send(Util.value_relation_name(field_obj.value_type))
+        field_value = if field_obj.has_many
+          field_values.select{ |v| v.field_id == field_obj.id }
         else
-          send(Util.value_relation_name(field.value_type)).detect{|v| v.field_id == field.id }
+          field_values.detect{ |v| v.field_id == field_obj.id }
         end
+        field_value
       end
 
       def build_dynabute_value(name: nil, field_id: nil, field: nil, **rest)
-        field = find_field(name, field_id, field)
-        send(Util.value_relation_name(field.value_type)).build(field_id: field.id, **rest)
+        field_obj = find_field(name, field_id, field)
+        send(Util.value_relation_name(field_obj.value_type)).build(field_id: field_obj.id, **rest)
+      end
+
+      # Returns value attribute for specified field.
+      # If field can have multiple values for single target model object,
+      # an array of values is returned, unless specific value_id is provided.
+      def get_dynabute_value(name: nil, field_id: nil, field: nil, value_id: nil)
+        field_obj = find_field(name, field_id, field)
+        value_obj = dynabute_value(field: field_obj)
+        return unless value_obj
+        if field_obj.has_many && value_id
+          value_obj = value_obj.detect{|v| v.id == value_id}
+        end
+        value_obj.is_a?(Array) ? value_obj.map(&:value) : value_obj&.value
+      end
+
+      # Sets the value in the target model object nested attribute structure.
+      # If field can have multiple values for single target model object,
+      # a new value will be added, unless specific value_id is provided.
+      #
+      # This method does not store changes in the database. "save" method should
+      # be called on target model to store all changes, or individually on every
+      # value record returned by this method.
+      def set_dynabute_value(name: nil, field_id: nil, field: nil, value: nil, value_id: nil)
+        field_obj = find_field(name, field_id, field)
+        value_obj = dynabute_value(field: field_obj)
+        if field_obj.has_many
+          if value_id
+            value_obj = value_obj.detect{|v| v.id == value_id} if value_obj
+            fail ValueNotFound unless value_obj
+          else
+            value_obj = build_dynabute_value(field: field_obj)
+          end
+        else
+          value_obj ||= build_dynabute_value(field: field_obj)
+        end
+        value_obj.value = value
+        value_obj
+      end
+
+      # Removes value from database and keeps dynabute relations up-to-date.
+      # If field can have multiple values for single target model object,
+      # all values will be removed, unless specific value_id is provided.
+      #
+      # This method stores changes in the database
+      def remove_dynabute_value(name: nil, field_id: nil, field: nil, value_id: nil)
+        field_obj = find_field(name, field_id, field)
+        value_obj = dynabute_value(field: field_obj)
+        if value_obj && field_obj.has_many && value_id
+          value_obj = value_obj.detect{|v| v.id == value_id}
+        end
+        if value_obj
+          result_obj = send(Util.value_relation_name(field_obj.value_type)).destroy(value_obj)
+          value_obj.is_a?(Array) ? result_obj : result_obj.first
+        end
       end
 
       def method_missing(*args)
@@ -63,11 +119,34 @@ module Dynabute
       end
 
       private
+
       def find_field(name, id, field)
-        name_or_id = {name: name, id: id}.compact
-        return nil if name_or_id.blank? && field.blank?
-        field_obj = field || Dynabute::Field.find_by(name_or_id.merge(target_model: self.class.to_s))
-        fail Dynabute::FieldNotFound.new(name_or_id, field) if field_obj.nil?
+        # Validate field argument
+        if field
+          unless field.is_a?(Dynabute::Field)
+            fail ArgumentError, 'Argument field must be Dynabute::Field'
+          end
+          return field
+        end
+        name_or_id = {}
+        # Validate name argument
+        if name
+          unless name.is_a?(String) || name.is_a?(Symbol)
+            fail ArgumentError, 'Argument name must be String or Symbol'
+          end
+          name_or_id[:name] = name.to_s
+        end
+        # Validate id argument
+        if id
+          unless id.is_a?(Integer)
+            fail ArgumentError, 'Argument id must be Integer'
+          end
+          name_or_id[:id] = id
+        end
+        name_or_id.reject!{ |k, v| v.blank? }
+        fail ArgumentError, 'Invalid arguments' if name_or_id.blank?
+        field_obj = Dynabute::Field.find_by(name_or_id.merge(target_model: self.class.to_s))
+        fail Dynabute::FieldNotFound.new(name_or_id) if field_obj.nil?
         field_obj
       end
 

--- a/spec/dummy/spec/value_spec.rb
+++ b/spec/dummy/spec/value_spec.rb
@@ -47,9 +47,23 @@ RSpec.describe Dynabute::Dynabutable, type: :model do
           end
           it 'can find by name' do
             expect(user.dynabute_value(name: int_field.name).try(:value)).to eq(1)
+            expect(user.dynabute_value(name: int_field.name.to_sym).try(:value)).to eq(1)
           end
           it 'can find by field' do
             expect(user.dynabute_value(field: int_field).try(:value)).to eq(1)
+          end
+          it 'raises ArgumentError when fetching value by invalid name argument' do
+            expect{ user.dynabute_value(name: nil) }.to raise_error(ArgumentError)
+            expect{ user.dynabute_value(name: '') }.to raise_error(ArgumentError)
+            expect{ user.dynabute_value(name: 123) }.to raise_error(ArgumentError)
+          end
+          it 'raises ArgumentError when fetching value by invalid field_id argument' do
+            expect{ user.dynabute_value(field_id: nil) }.to raise_error(ArgumentError)
+            expect{ user.dynabute_value(field_id: '1') }.to raise_error(ArgumentError)
+          end
+          it 'raises ArgumentError when fetching value by invalid field argument' do
+            expect{ user.dynabute_value(field: nil) }.to raise_error(ArgumentError)
+            expect{ user.dynabute_value(field: {}) }.to raise_error(ArgumentError)
           end
         end
 
@@ -75,7 +89,7 @@ RSpec.describe Dynabute::Dynabutable, type: :model do
         end
 
         it 'raises Dynabute::FieldNoFoundError when field not found' do
-          expect{ user.dynabute_value(name: 'I dont exist') }.to raise_error(Dynabute::FieldNotFound)
+          expect{ user.dynabute_value(name: "I don't exist") }.to raise_error(Dynabute::FieldNotFound)
         end
       end
 
@@ -111,6 +125,212 @@ RSpec.describe Dynabute::Dynabutable, type: :model do
               expect(user.dynabute_value(field: int_many_field).map(&:id)).to include(existing_value.id, nil)
             end
           end
+        end
+      end
+    end
+
+    describe '#get_dynabute_value' do
+      context 'has one' do
+        context 'when value record exists' do
+          let!(:value) { Dynabute::Values::IntegerValue.create(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_field.id, value: 42)}
+          it 'returns literal value found by field' do
+            expect(user.get_dynabute_value(field: int_field)).to eq(42)
+          end
+          it 'returns literal value found by field name' do
+            expect(user.get_dynabute_value(name: int_field.name)).to eq(42)
+          end
+          it 'returns literal value found by field id' do
+            expect(user.get_dynabute_value(field_id: int_field.id)).to eq(42)
+          end
+        end
+        context 'when value record does not exist' do
+          it 'returns nil' do
+            expect(user.get_dynabute_value(field: int_field)).to be_nil
+          end
+        end
+      end
+      context 'has_many' do
+        let!(:int_many_field) { Dynabute::Field.create(name: 'int many field', value_type: :integer, target_model: 'User', has_many: true) }
+        context 'when value records exist' do
+          let!(:first_value) { Dynabute::Values::IntegerValue.create!(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_many_field.id, value: 1) }
+          let!(:second_value) { Dynabute::Values::IntegerValue.create!(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_many_field.id, value: 2) }
+          context 'value_id argument is not provided' do
+            it 'returns array of literal values' do
+              expect(user.get_dynabute_value(field: int_many_field)).to match_array([1, 2])
+            end
+          end
+          context 'value_id argument is provided' do
+            it 'returns literal value for given value record' do
+              expect(user.get_dynabute_value(field: int_many_field, value_id: second_value.id)).to eq(2)
+            end
+          end
+        end
+        context 'when value records do not exist' do
+          context 'value_id argument is not provided' do
+            it 'returns empty array' do
+              expect(user.get_dynabute_value(field: int_many_field)).to match_array([])
+            end
+          end
+          context 'value_id argument is provided' do
+            it 'returns nil' do
+              expect(user.get_dynabute_value(field: int_many_field, value_id: 999)).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'setting value' do
+    let!(:user) { User.create }
+    context 'has_one' do
+      let!(:int_field) { Dynabute::Field.create(name: 'int field', value_type: :integer, target_model: 'User') }
+      context 'when value record does not exist' do
+        subject { user.set_dynabute_value(field: int_field, value: 42) }
+        it 'creates new unsaved association' do
+          expect(subject).to be_a(Dynabute::Values::IntegerValue)
+          expect(subject.attributes).to include({
+            'field_id' => int_field.id,
+            'dynabutable_type' => 'User',
+            'dynabutable_id' => user.id,
+            'value' => 42,
+            'id' => nil
+          })
+          expect(subject.new_record?).to be true
+        end
+      end
+      context 'when value record exists' do
+        let!(:value) { Dynabute::Values::IntegerValue.create(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_field.id, value: 1)}
+        subject { user.set_dynabute_value(field: int_field, value: 42) }
+        it 'changes existing association without saving' do
+          expect(subject).to be_a(Dynabute::Values::IntegerValue)
+          expect(subject.attributes).to include({
+            'field_id' => int_field.id,
+            'dynabutable_type' => 'User',
+            'dynabutable_id' => user.id,
+            'value' => 42,
+            'id' => value.id
+          })
+          expect(subject.persisted?).to be true
+        end
+      end
+    end
+    context 'has_many' do
+      let!(:int_many_field) { Dynabute::Field.create(name: 'int many field', value_type: :integer, target_model: 'User', has_many: true) }
+      context 'when value records do not exist' do
+        context 'when value_id argument is not provided' do
+          subject { user.set_dynabute_value(field: int_many_field, value: 42) }
+          it 'creates new unsaved association' do
+            expect(subject).to be_a(Dynabute::Values::IntegerValue)
+            expect(subject.attributes).to include({
+              'field_id' => int_many_field.id,
+              'dynabutable_id' => user.id,
+              'dynabutable_type' => 'User',
+              'value' => 42,
+              'id' => nil
+            })
+            expect(subject.new_record?).to be true
+          end
+        end
+        context 'when value_id argument is provided' do
+          subject { user.set_dynabute_value(field: int_many_field, value: 42, value_id: 999) }
+          it 'raises ValueNotFound exception' do
+            expect { subject }.to raise_error(Dynabute::Dynabutable::ValueNotFound)
+          end
+        end
+      end
+      context 'when value records exist' do
+        let!(:first_value) { Dynabute::Values::IntegerValue.create!(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_many_field.id, value: 1) }
+        let!(:second_value) { Dynabute::Values::IntegerValue.create!(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_many_field.id, value: 2) }
+        context 'when value_id argument is not provided' do
+          subject { user.set_dynabute_value(field: int_many_field, value: 42) }
+          it 'created new unsaved association' do
+            expect(subject).to be_a(Dynabute::Values::IntegerValue)
+            expect(subject.attributes).to include({
+              'field_id' => int_many_field.id,
+              'dynabutable_type' => 'User',
+              'dynabutable_id' => user.id,
+              'value' => 42,
+              'id' => nil
+            })
+            expect(subject.new_record?).to be true
+          end
+        end
+        context 'when value_id argument is provided' do
+          subject { user.set_dynabute_value(field: int_many_field, value: 42, value_id: second_value.id) }
+          it 'changes existing association without saving' do
+            expect(subject).to be_a(Dynabute::Values::IntegerValue)
+            expect(subject.attributes).to include({
+              'field_id' => int_many_field.id,
+              'dynabutable_type' => 'User',
+              'dynabutable_id' => user.id,
+              'value' => 42,
+              'id' => second_value.id
+            })
+            expect(subject.persisted?).to be true
+          end
+        end
+      end
+    end
+  end
+
+  describe 'deleting value' do
+    let!(:user) { User.create }
+    context 'has_one' do
+      let!(:int_field) { Dynabute::Field.create(name: 'int field', value_type: :integer, target_model: 'User') }
+      context 'when value record exists' do
+        let!(:value) { Dynabute::Values::IntegerValue.create(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_field.id, value: 1)}
+        subject { user.remove_dynabute_value(field: int_field) }
+        it 'returns deleted association' do
+          expect(subject).to be_a(Dynabute::Values::IntegerValue)
+          expect(subject.attributes).to include({
+            'field_id' => value.field_id,
+            'dynabutable_type' => value.dynabutable_type,
+            'dynabutable_id' => value.dynabutable_id,
+            'value' => value.value,
+            'id' => value.id
+          })
+          expect(subject.destroyed?).to be true
+        end
+      end
+      context 'when value record does not exist' do
+        subject { user.remove_dynabute_value(field: int_field) }
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+    context 'has_many' do
+      let!(:int_many_field) { Dynabute::Field.create(name: 'int many field', value_type: :integer, target_model: 'User', has_many: true) }
+      context 'when value records exist' do
+        let!(:first_value) { Dynabute::Values::IntegerValue.create!(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_many_field.id, value: 1) }
+        let!(:second_value) { Dynabute::Values::IntegerValue.create!(dynabutable_id: user.id, dynabutable_type: 'User', field_id: int_many_field.id, value: 2) }
+        context 'when value_id argument is not provided' do
+          subject { user.remove_dynabute_value(field: int_many_field) }
+          it 'returns array of deleted associations' do
+            expect(subject).to all(be_a(Dynabute::Values::IntegerValue))
+            expect(subject.map(&:destroyed?)).to all(be true)
+          end
+        end
+        context 'when value_id argument is provided' do
+          subject { user.remove_dynabute_value(field: int_many_field, value_id: second_value.id) }
+          it 'returns deleted association' do
+            expect(subject).to be_a(Dynabute::Values::IntegerValue)
+            expect(subject.attributes).to include({
+              'field_id' => second_value.field_id,
+              'dynabutable_type' => second_value.dynabutable_type,
+              'dynabutable_id' => second_value.dynabutable_id,
+              'value' => second_value.value,
+              'id' => second_value.id
+            })
+            expect(subject.destroyed?).to be true
+          end
+        end
+      end
+      context 'when value records do not exist' do
+        subject { user.remove_dynabute_value(field: int_many_field) }
+        it 'returns empty array' do
+          expect(subject).to match_array([])
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,9 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Use the specified formatter
+  config.formatter = :documentation
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
Allow update value for fields that do not have inserted record in
appropriate value table.

Currently, initial creation of values records are done through `build_dynabute_value` method. If we want to update existing value, we can't use `build_dynabute_value` as that would result in new value being created for the same field.
The idea here is to automatically call `build_dynabute_value` if the record doesn't exist, and have helper functions to achieve that.
