### PR TITLE
Delete dynabutes when deleting model

### DIFF
--- a/lib/dynabute/dynabutable.rb
+++ b/lib/dynabute/dynabutable.rb
@@ -12,7 +12,7 @@ module Dynabute
       include NestedAttributes::API
 
       (Dynabute::Field::TYPES).each do |t|
-        has_many Util.value_relation_name(t), class_name: Util.value_class_name(t), as: :dynabutable, inverse_of: 'dynabutable'
+        has_many Util.value_relation_name(t), class_name: Util.value_class_name(t), as: :dynabutable, inverse_of: 'dynabutable', dependent: :delete_all
         accepts_nested_attributes_for Util.value_relation_name(t), reject_if: proc{ |param| param[:value].blank? }, allow_destroy: true
       end
 


### PR DESCRIPTION
Fixes issue #7. Added `dependent: :delete_all`. 